### PR TITLE
Improvement/colored messages

### DIFF
--- a/src/run-gcc
+++ b/src/run-gcc
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # Function to display an error message and exit
 error_exit() {
-  echo "Error: $1" >&2
+  echo -e "\e[31m\e[1mError:\e[0m $1" >&2
   exit 1
 }
 
@@ -67,12 +67,12 @@ compare_output() {
   local expected_file="$2"
   local show_diff="$3"
   if diff <(echo "$program_output") "$expected_file" >/dev/null; then
-    echo "Test Passed: Program output matches the expected output."
+    echo -e "\e[32m\e[1mSuccess:\e[0m Program output matches the expected output."
   else
-    echo "Test Failed: Program output does not match the expected output."
+    echo -e "\e[31m\e[1mFailure:\e[0m Program output does not match the expected output."
     if [[ "$show_diff" == "true" ]]; then
       echo
-      echo "Difference:"
+      echo -e "\e[34m\e[1mDifference:\e[0m"
       diff <(echo "$program_output") "$expected_file" || true
     fi
     return 1

--- a/tests/test_cases.bats
+++ b/tests/test_cases.bats
@@ -46,25 +46,25 @@ setup() {
 @test "Compile and run a valid C program with input and expected output" {
   run src/run-gcc "$valid_c_with_input_file" -i "$input_file" -e "$expected_output_file"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Test Passed: Program output matches the expected output."* ]]
+  [[ "$output" == *"Program output matches the expected output."* ]]
 }
 
 @test "Compile and run a valid C++ program with input and expected output" {
   run src/run-gcc "$valid_cpp_with_input_file" -i "$input_file" -e "$expected_output_file"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Test Passed: Program output matches the expected output."* ]]
+  [[ "$output" == *"Program output matches the expected output."* ]]
 }
 
 @test "Compile and run a valid C program with input and show diff on mismatch" {
   run src/run-gcc "$valid_c_with_input_file" -i "$input_file" -e "$wrong_output_file" -d
   [ "$status" -ne 0 ]
-  [[ "$output" == *"Test Failed: Program output does not match the expected output."* ]]
+  [[ "$output" == *"Program output does not match the expected output."* ]]
   [[ "$output" == *"Difference:"* ]]
 }
 
 @test "Compile and run a valid C++ program with input and show diff on mismatch" {
   run src/run-gcc "$valid_cpp_with_input_file" -i "$input_file" -e "$wrong_output_file" -d
   [ "$status" -ne 0 ]
-  [[ "$output" == *"Test Failed: Program output does not match the expected output."* ]]
+  [[ "$output" == *"Program output does not match the expected output."* ]]
   [[ "$output" == *"Difference:"* ]]
 }


### PR DESCRIPTION
# Pull Request

## Description  
Display output messages indicating success or failure in color (green for success, red for error) with bold styling for clarity.

## Related Issues  
Closes: #6 

## Changes Made  
- Added ANSI escape codes in the Bash script to colorize output messages.  
- Styled success messages with bold green (`\033[1;32m`) and error messages with bold red (`\033[1;31m`).  
- Improved readability of script output for quick visual feedback.

## Checklist  
- [x] Code follows the project’s style guidelines  
- [x] Tests have been added or updated  
- [ ] Documentation has been updated  
- [x] All tests pass locally  

## Additional Notes  
This enhancement improves user experience by making test results more immediately visible. It's especially useful in automated testing environments or CI pipelines where scanning for colored text is faster than reading through logs.
