### PR TITLE
Setup Docker Builders for Deb and Arch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Exclude test files and directories
+tests/
+
+# Exclude package files generated during build
+*.deb
+*.pkg.tar.*
+
+# Exclude temporary and log files
+*.log
+*.swp
+*.o
+*.out
+*.tmp
+
+# Optionally exclude documentation or non-essential files
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Build products
 *.deb
+*.build
 *.buildinfo
 *.changes
 *.dsc
@@ -13,6 +14,7 @@
 
 # Debian packaging artifacts
 debian/.debhelper/
+debian/build/
 debian/files
 debian/*.debhelper.log
 debian/*.substvars
@@ -30,7 +32,7 @@ debian/*.prerm
 
 # Ignore pkg/ except Arch templates
 pkg/*
-!pkg/arch/
+# !pkg/arch/
 !pkg/arch/PKGBUILD
 
 # Editor and IDE files

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 {deb|arch}"
+  exit 1
+fi
+
+TARGET=$1
+
+if [ "$TARGET" = "deb" ]; then
+  echo "Building Debian package using debuild..."
+  docker-compose run --rm debian-builder
+elif [ "$TARGET" = "arch" ]; then
+  echo "Building Arch package using makepkg..."
+  docker-compose run --rm arch-builder
+else
+  echo "Unknown target: $TARGET"
+  echo "Usage: $0 {deb|arch}"
+  exit 1
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.9'
+
+services:
+  debian-builder:
+    build:
+      context: .
+      dockerfile: docker/deb/Dockerfile
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    container_name: run-gcc-deb
+    # Use debuild to build the Debian package; -us -uc skips signing.
+    command: bash -c "debuild -us -uc && ls ../"
+
+  arch-builder:
+    build:
+      context: .
+      dockerfile: docker/arch/Dockerfile
+    volumes:
+      - .:/workspace
+    working_dir: /workspace/pkg/arch
+    container_name: run-gcc-arch
+    # Run makepkg in the Arch packaging folder.
+    command: bash -c "makepkg -f && ls"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,12 @@ services:
     working_dir: /workspace
     container_name: run-gcc-deb
     # Use debuild to build the Debian package; -us -uc skips signing.
-    command: bash -c "debuild -us -uc && ls ../"
+    command: >
+      bash -c "
+      debuild -us -uc &&
+      mkdir -p debian/build &&
+      mv ../*.deb ../*.build* ../*.changes ../*.dsc ../*.tar.* debian/build/ &&
+      ls debian/build"
 
   arch-builder:
     build:

--- a/docker/arch/Dockerfile
+++ b/docker/arch/Dockerfile
@@ -1,0 +1,17 @@
+FROM archlinux:latest
+
+# Update Arch and install required packages (base-devel, git, etc.)
+RUN pacman -Syu --noconfirm && \
+  pacman -S --noconfirm base-devel bats git man-db && \
+  # Create a non-root user for building since makepkg cannot run as root.
+  useradd -m builder && \
+  echo "builder ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
+
+# Switch to the newly created builder user.
+USER builder
+
+# Set the workspace directory.
+WORKDIR /workspace
+
+# The PKGBUILD and related packaging files in pkg/arch are expected to be in the project.
+# Volume mounting (via docker-compose) makes this accessible.

--- a/docker/deb/Dockerfile
+++ b/docker/deb/Dockerfile
@@ -1,0 +1,20 @@
+# Use a stable Debian slim base image.
+FROM debian:stable-slim
+
+# Set noninteractive mode for apt-get.
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update packages and install build tools for Debian packaging.
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  devscripts \
+  lintian \
+  man-db \
+  bats && \
+  rm -rf /var/lib/apt/lists/*
+
+# Use a generic workspace directory.
+WORKDIR /workspace
+
+# The source code will be volume-mounted (see docker-compose) so no COPY here.
+# When you run debuild, it uses the debian/ packaging files to create the package.

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,13 +1,13 @@
 # Maintainer: Md. Dipu <srdipu@hotmail.com>
 pkgname=run-gcc
 pkgver=1.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Compile and run C/C++ programs"
 arch=('any')
 url="https://github.com/Md-Dipu/run-gcc"
 license=('MIT')
 depends=('gcc' 'file')
-source=("$url/archive/v$pkgver.tar.gz")
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('SKIP')
 
 package() {


### PR DESCRIPTION
## Description
This PR sets up a Docker build environment for both Debian and Arch Linux distributions, facilitating the development and testing process for the run-gcc shell script project. By providing dedicated Docker configurations for each target, it becomes easier to standardize the development workflow and ensure compatibility across different environments.

## Changes Made
- **docker/deb/Dockerfile:** Added Dockerfile configuration tailored for Debian-based builds.
- **docker/arch/Dockerfile:** Added Dockerfile configuration tailored for Arch-based builds.
- **.dockerignore:** Created to optimize the build context.
- **docker-compose.yml:** Configured to orchestrate both Docker environments for seamless integration during development.

## Checklist
- [ ] Code follows the project’s style guidelines
- [ ] Tests have been added or updated
- [ ] Documentation has been updated
- [ ] All tests pass locally

## Additional Notes
This addition aims to streamline the process of generating and testing the shell script within controlled environments via Docker. Future improvements may include further automation and integration with CI/CD pipelines to enhance deployment consistency.