### PR TITLE
Fix broken Code of Conduct link in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Thank you for considering contributing to `run-gcc`! Contributions are welcome a
 
 ## Code of Conduct
 
-Please adhere to the [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a welcoming and inclusive environment for everyone.
+Please adhere to the [Code of Conduct](../CODE_OF_CONDUCT.md) to ensure a welcoming and inclusive environment for everyone.
 
 ## Guidelines for Contributions
 


### PR DESCRIPTION
## Description  
This pull request fixes a broken or outdated link to the **Code of Conduct** in the `CONTRIBUTING.md` file. The correct link ensures contributors can easily access and adhere to the project's community standards.

## Changes Made  
- Fixed the hyperlink for `Code of Conduct` in `CONTRIBUTING.md`  
- Verified that the updated link correctly redirects to the intended section/document  

## Checklist  
- [x] Code follows the project’s style guidelines  
- [ ] Tests have been added or updated 
- [x] Documentation has been updated  
- [ ] All tests pass locally 

## Additional Notes  
This is a minor documentation fix but important for ensuring that new contributors have proper guidance on expected community behavior.
